### PR TITLE
getmyvax_org: Remove `eligibility` field

### DIFF
--- a/vaccine_feed_ingest/runners/us/getmyvax_org/normalize.py
+++ b/vaccine_feed_ingest/runners/us/getmyvax_org/normalize.py
@@ -153,7 +153,6 @@ class GMVLocation(BaseModel):
     info_url: Optional[str]
     booking_phone: Optional[str]
     booking_url: Optional[str]
-    eligibility: Optional[str]
     description: Optional[str]
     requires_waitlist: bool
     meta: Optional[dict]


### PR DESCRIPTION
getmyvax.org is removing the `eligibility` field from our location model as part of a move solidify a v1 API: https://github.com/usdigitalresponse/univaf/issues/154. That change should land later today.

I don’t think this change should really cause any issues since the field is already marked as optional. Unfortunately, I don’t have a fully working setup locally to run the tests, but this is pretty narrow.

## Before Opening a PR
- [ ] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [ ] I ran auto-formatting: `poetry run tox -e lint-fix`
